### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
     - uses: actions/checkout@main
     - name: Publish to Dockerhub Registry
-      uses: elgohr/Publish-Docker-Github-Action@2.18
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: jackharrhy/xavier
         username: ${{ secrets.DOCKER_USERNAME }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore